### PR TITLE
mysql mybatis 설정 추가 및 연동 확인 테스트 코드 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,11 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    // mybatis
+    implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.2.0'
+    // MySQL connector
+    runtimeOnly 'mysql:mysql-connector-java'
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,11 @@ dependencies {
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.2.0'
     // MySQL connector
     runtimeOnly 'mysql:mysql-connector-java'
+
+    //lombok
+    implementation 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
 }
 
 test {

--- a/mysql-docker-compose.yml
+++ b/mysql-docker-compose.yml
@@ -1,0 +1,15 @@
+# 로컬 개발 환경 설정을 위한 MySQL docker compose 파일
+version: "3.9"
+services:
+  mysql:
+    image: mysql:5.7
+    ports:
+      - "127.0.0.1:3306:3306"
+    environment:
+      - MYSQL_ROOT_PASSWORD=1234
+      - MYSQL_DATABASE=cozy
+      - MYSQL_USER=cozy
+      - MYSQL_PASSWORD=1234
+    command:
+      - --character-set-server=utf8
+      - --collation-server=utf8_unicode_ci

--- a/src/main/java/com/cozy/domain/user/User.java
+++ b/src/main/java/com/cozy/domain/user/User.java
@@ -1,19 +1,24 @@
 package com.cozy.domain.user;
 
 import java.time.LocalDateTime;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
+import lombok.Value;
 
-@AllArgsConstructor
-@Getter
-public final class User {
+/**
+ * @Value?
+ * Value 어노테이션은 불변 객체를 만들어 주는 역할을 한다.
+ * 클래스를 final로 필드를 private, final로 만들어준다.
+ * 그리고 @AllArgConstructor, @ToString, @EqualsAndHashCode 어노테이션을 가지고 있다.
+ */
+@Value
+public class User {
 
-  private final Long id;
-  private final String loginId;
-  private final String password;
-  private final String email;
-  private final String phoneNumber;
-  private final LocalDateTime createdAt;
-  private final LocalDateTime deletedAt;
-  private final Boolean isDeleted;
+  Long id;
+  String loginId;
+  String password;
+  String email;
+  String phoneNumber;
+  LocalDateTime createdAt;
+  LocalDateTime deletedAt;
+  LocalDateTime updatedAt;
+  Boolean isDeleted;
 }

--- a/src/main/java/com/cozy/domain/user/User.java
+++ b/src/main/java/com/cozy/domain/user/User.java
@@ -1,0 +1,19 @@
+package com.cozy.domain.user;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public final class User {
+
+  private final Long id;
+  private final String loginId;
+  private final String password;
+  private final String email;
+  private final String phoneNumber;
+  private final LocalDateTime createdAt;
+  private final LocalDateTime deletedAt;
+  private final Boolean isDeleted;
+}

--- a/src/main/java/com/cozy/domain/user/dto/CreateUserDto.java
+++ b/src/main/java/com/cozy/domain/user/dto/CreateUserDto.java
@@ -1,0 +1,14 @@
+package com.cozy.domain.user.dto;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class CreateUserDto {
+
+  String loginId;
+  String password;
+  String email;
+  String phoneNumber;
+}

--- a/src/main/java/com/cozy/domain/user/dto/GetOneUserDto.java
+++ b/src/main/java/com/cozy/domain/user/dto/GetOneUserDto.java
@@ -1,0 +1,14 @@
+package com.cozy.domain.user.dto;
+
+import lombok.Value;
+import org.apache.ibatis.type.Alias;
+
+@Value
+@Alias("GetOneUserDto")
+public class GetOneUserDto {
+
+  String loginId;
+  String password;
+  String email;
+  String phoneNumber;
+}

--- a/src/main/java/com/cozy/domain/user/mapper/UserMapper.java
+++ b/src/main/java/com/cozy/domain/user/mapper/UserMapper.java
@@ -1,0 +1,13 @@
+package com.cozy.domain.user.mapper;
+
+import com.cozy.domain.user.dto.CreateUserDto;
+import com.cozy.domain.user.dto.GetOneUserDto;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface UserMapper {
+
+  Long createUser(CreateUserDto createUserDto);
+
+  GetOneUserDto getOneUser(Long id);
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,3 +5,11 @@ spring:
     username: cozy
     password: 1234
     driver-class-name: com.mysql.cj.jdbc.Driver
+  # schema.sql 파일을 스프링 부트를 띄울때마다 실행 (always 옵션)
+  sql:
+    init:
+      mode: always
+
+mybatis:
+  # 매퍼 클래스와 xml 파일을 매핑
+  mapper-locations: mapper/*.xml

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,3 +13,4 @@ spring:
 mybatis:
   # 매퍼 클래스와 xml 파일을 매핑
   mapper-locations: mapper/*.xml
+  type-aliases-package: com.cozy.domain

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,1 +1,7 @@
-
+spring:
+  # 데이터 베이스 설정
+  datasource:
+    url: jdbc:mysql://localhost:3306/cozy?serverTimezone=UTC&characterEncoding=UTF-8
+    username: cozy
+    password: 1234
+    driver-class-name: com.mysql.cj.jdbc.Driver

--- a/src/main/resources/mapper/userMapper.xml
+++ b/src/main/resources/mapper/userMapper.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+  PUBLIC "-//mybatis.org//DTD Mapper 3.0//ENG"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.cozy.domain.user.mapper.UserMapper">
+  <insert id="createUser">
+    insert into USER (login_id, password, email, phone_number)
+    values (#{loginId}, #{password}, #{email}, #{phoneNumber})
+  </insert>
+
+  <select id="getOneUser" resultType="GetOneUserDto">
+    select login_id, password, email, phone_number
+    from USER
+    WHERE ID = #{id}
+  </select>
+</mapper>

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -9,6 +9,7 @@ create table USER
     phone_number varchar(25)  not null,
     created_at   TIMESTAMP    not null DEFAULT CURRENT_TIMESTAMP,
     deleted_at   TIMESTAMP    null,
+    updated_at   TIMESTAMP    not null DEFAULT CURRENT_TIMESTAMP,
     is_deleted   BOOLEAN      not null DEFAULT false,
 
     PRIMARY KEY (id)

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,15 @@
+DROP TABLE IF EXISTS USER;
+
+create table USER
+(
+    id           bigint       not null auto_increment,
+    login_id     varchar(25)  not null,
+    password     varchar(25)  not null,
+    email        varchar(100) not null,
+    phone_number varchar(25)  not null,
+    created_at   TIMESTAMP    not null DEFAULT CURRENT_TIMESTAMP,
+    deleted_at   TIMESTAMP    null,
+    is_deleted   BOOLEAN      not null DEFAULT false,
+
+    PRIMARY KEY (id)
+)

--- a/src/test/java/com/cozy/MySQLConnectionTest.java
+++ b/src/test/java/com/cozy/MySQLConnectionTest.java
@@ -1,0 +1,33 @@
+package com.cozy;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.sql.Connection;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class MySQLConnectionTest {
+
+  /**
+   * @Autowired?
+   * 필요한 의존 객체의 타입에 해당하는 빈을 찾아 주입한다.
+   * 만약 의존 객체의 타입을 찾지 못한다면, 변수명과 빈 이름이 일치하는 빈을 주입한다.
+   * 의존 객체의 타입이 여러가지라면, 빈이 주입되지 않는다.
+   * 다만, @Primary 또는 @Qualifier 어노테이션을 적절히 사용하면 의존 객체의 타입이 여러가지여도 빈을 주입 받을 수 있다.
+   */
+  @Autowired
+  private SqlSessionFactory sqlSessionFactory;
+
+  @Test
+  public void MySQL_연동테스트() {
+
+    try (Connection con = sqlSessionFactory.openSession().getConnection()) {
+      assertFalse(con.isClosed());
+    } catch (Exception e) {
+      fail();
+    }
+  }
+}

--- a/src/test/java/com/cozy/domain/user/UserMapperTest.java
+++ b/src/test/java/com/cozy/domain/user/UserMapperTest.java
@@ -1,0 +1,26 @@
+package com.cozy.domain.user;
+
+import com.cozy.domain.user.dto.CreateUserDto;
+import com.cozy.domain.user.mapper.UserMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class UserMapperTest {
+
+  @Autowired
+  private UserMapper userMapper;
+
+  @Test
+  public void 유저_생성() {
+    CreateUserDto user = CreateUserDto.builder()
+        .loginId("cozy")
+        .password("1234!@")
+        .phoneNumber("01012344321")
+        .email("cozy@gmail.com")
+        .build();
+    userMapper.createUser(user);
+  }
+
+}

--- a/src/test/java/com/cozy/domain/user/UserMapperTest.java
+++ b/src/test/java/com/cozy/domain/user/UserMapperTest.java
@@ -1,6 +1,9 @@
 package com.cozy.domain.user;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import com.cozy.domain.user.dto.CreateUserDto;
+import com.cozy.domain.user.dto.GetOneUserDto;
 import com.cozy.domain.user.mapper.UserMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,13 +17,24 @@ class UserMapperTest {
 
   @Test
   public void 유저_생성() {
+
+    //given
     CreateUserDto user = CreateUserDto.builder()
         .loginId("cozy")
         .password("1234!@")
         .phoneNumber("01012344321")
         .email("cozy@gmail.com")
         .build();
-    userMapper.createUser(user);
+
+    //when
+    Long id = userMapper.createUser(user);
+
+    //then
+    GetOneUserDto findUser = userMapper.getOneUser(id);
+    assertEquals(user.getEmail(), findUser.getEmail());
+    assertEquals(user.getPassword(), findUser.getPassword());
+    assertEquals(user.getLoginId(), findUser.getLoginId());
+    assertEquals(user.getPhoneNumber(), findUser.getPhoneNumber());
   }
 
 }


### PR DESCRIPTION
## 작업 내용
- mybatis 연동 의존성 추가
- mysql 연동 의존성 추가
- mysql 연동 설정 코드 추가
- mysql 연동 테스트 코드 추가
- 로컬 디비 설정을 위한 mysql docker compose 파일 추가
- mybatis 연동 확인을 위한 user 도메인 생성 및 유저 생성 기능 추가
- lombok 어노테이션 추가

## 체크 리스트
* [conventions](https://github.com/f-lab-edu/cozy/wiki/conventions)
- [x] 구글 자바 컨벤션 준수 여부
- [x] 객체지향 생활체조 원칙(3가지만) 준수 여부
- [x] 어노테이션에 주석 추가 여부  
- [x] 커밋 메시지 컨벤션 준수 여부
- [x] 테스트 코드 작성 여부

## 결과 (스크린샷 포함 가능)

## 참조자
@didrlgus, @youngsuk-kim, @f-lab-jd